### PR TITLE
fix highlight in message list in dark mode

### DIFF
--- a/app/components/SingleMessage.tsx
+++ b/app/components/SingleMessage.tsx
@@ -13,7 +13,7 @@ export default function SingleMessage({ message }: { message: ThreadMessage }) {
 
   const currentMessage = parseInt(messageId ?? '0')
   const isLoading = transition.state === 'loading' && transition.location?.pathname?.endsWith(`message/${message.id}`)
-  const isCurrentClass = isLoading || currentMessage === message.id ? `bg-blue-200 shadow-md` : ``
+  const isCurrentClass = isLoading || currentMessage === message.id ? `bg-blue-200 dark:bg-slate-600 dark:text-gray-100 shadow-md` : ``
   const isCurrentUserClass = context.currentUser?.username === message.author ? `border-red-500` : `border-transparent`
 
   return (

--- a/app/routes/board/$boardId/thread/$threadId.tsx
+++ b/app/routes/board/$boardId/thread/$threadId.tsx
@@ -32,9 +32,6 @@ export default function MessagesList() {
 
   useEffect(() => {
     const handler = function (e: Event) {
-      console.log(e.target); // element that was swiped
-      console.log((e as SwipeEvent).detail); // see event data below
-
       if (ref.current !== null) {
         ref.current.style.transform = "translateX(83.33333333%)"
       }


### PR DESCRIPTION
The highlight used the light mode settings in the message list resulting in a pretty badly readable display.

<img width="492" alt="image" src="https://user-images.githubusercontent.com/251322/150636742-b1843c83-ca76-4c4a-92aa-a255a13b2d30.png">
